### PR TITLE
feat: implement integer and floating point parameters

### DIFF
--- a/gui/model/parameter.py
+++ b/gui/model/parameter.py
@@ -114,3 +114,85 @@ class BoolParameter(Parameter[bool]):
             + f'value: {self.value}, '
             + f'valid: {self.valid})'
         )
+
+
+class IntParameter(Parameter[int]):
+    """
+    An integer parameter in the GUI with optional bounds.
+    """
+
+    value_changed = Signal(int, bool)
+
+    def __init__(
+            self,
+            name: str, description: str, flag: str,
+            default_value: int,
+            lower_bound: int = None,
+            upper_bound: int = None
+    ) -> None:
+        super().__init__(name, description, flag, default_value)
+        self.lower_bound = lower_bound
+        self.upper_bound = upper_bound
+
+    @property
+    def valid(self) -> bool:
+        """Check if current value is within bounds."""
+        if self.lower_bound is not None and self._value < self.lower_bound:
+            return False
+        if self.upper_bound is not None and self._value > self.upper_bound:
+            return False
+        return True
+
+    def to_cli(self) -> str:
+        return f"{self.flag} {self.value}"
+
+    def __str__(self) -> str:
+        bounds = f"[{self.lower_bound}, {self.upper_bound}]"
+        return (
+            f'IntParameter('
+            + f'name: "{self.name}", '
+            + f'value: {self.value}, '
+            + f'bounds: {bounds}, '
+            + f'valid: {self.valid})'
+        )
+
+
+class FloatParameter(Parameter[float]):
+    """
+    A floating point parameter in the GUI with optional bounds.
+    """
+
+    value_changed = Signal(float, bool)
+
+    def __init__(
+            self,
+            name: str, description: str, flag: str,
+            default_value: float,
+            lower_bound: float = None,
+            upper_bound: float = None
+    ) -> None:
+        super().__init__(name, description, flag, default_value)
+        self.lower_bound = lower_bound
+        self.upper_bound = upper_bound
+
+    @property
+    def valid(self) -> bool:
+        """Check if current value is within bounds."""
+        if self.lower_bound is not None and self._value < self.lower_bound:
+            return False
+        if self.upper_bound is not None and self._value > self.upper_bound:
+            return False
+        return True
+
+    def to_cli(self) -> str:
+        return f"{self.flag} {self.value}"
+
+    def __str__(self) -> str:
+        bounds = f"[{self.lower_bound}, {self.upper_bound}]"
+        return (
+            f'FloatParameter('
+            + f'name: "{self.name}", '
+            + f'value: {self.value}, '
+            + f'bounds: {bounds}, '
+            + f'valid: {self.valid})'
+        )

--- a/gui/widgets/parameter_widget.py
+++ b/gui/widgets/parameter_widget.py
@@ -2,11 +2,16 @@ from typing import Any
 from abc import ABC
 
 from PySide6.QtCore import Qt, Slot
-from PySide6.QtWidgets import QWidget, QLabel, QVBoxLayout, QCheckBox
+from PySide6.QtWidgets import (
+    QWidget, QLabel, QVBoxLayout, QCheckBox,
+    QSpinBox, QDoubleSpinBox
+)
 
 from gui.model.parameter import (
     Parameter,
     BoolParameter,
+    IntParameter,
+    FloatParameter,
 )
 
 
@@ -73,6 +78,10 @@ class ParameterWidget(ABC, QWidget, metaclass=AbstractQWidgetMeta):
 
         if isinstance(parameter, BoolParameter):
             return label, BoolParameterWidget(parameter)
+        elif isinstance(parameter, IntParameter):
+            return label, IntParameterWidget(parameter)
+        elif isinstance(parameter, FloatParameter):
+            return label, FloatParameterWidget(parameter)
 
         # TODO: implement selection of widget subclass for other parameter types
         raise NotImplementedError(f"ParameterWidget#from_parameter not implemented for {type(parameter)}!")
@@ -115,3 +124,104 @@ class BoolParameterWidget(ParameterWidget):
     @Slot(bool, bool)
     def _parameter_value_changed(self, new_value: bool, valid: bool) -> None:
         self._checkbox.setChecked(new_value)
+
+
+class IntParameterWidget(ParameterWidget):
+    """
+    A widget to edit an integer parameter with optional bounds.
+    """
+
+    def __init__(self, parameter: IntParameter) -> None:
+        """
+        Initialize an IntParameterWidget object.
+
+        :param parameter: the integer parameter to reference
+        :type parameter: IntParameter
+        """
+        super().__init__(parameter)
+
+        layout = QVBoxLayout(self)
+        self._spinbox = QSpinBox()
+        
+        # Set bounds if specified
+        if parameter.lower_bound is not None:
+            self._spinbox.setMinimum(parameter.lower_bound)
+        else:
+            self._spinbox.setMinimum(-2147483648)  # INT_MIN
+            
+        if parameter.upper_bound is not None:
+            self._spinbox.setMaximum(parameter.upper_bound)
+        else:
+            self._spinbox.setMaximum(2147483647)  # INT_MAX
+            
+        self._spinbox.setValue(parameter.value)
+        layout.addWidget(self._spinbox)
+
+        # Add bounds label if bounds are specified
+        if parameter.lower_bound is not None or parameter.upper_bound is not None:
+            bounds_text = f"Valid range: [{parameter.lower_bound or '-∞'}, {parameter.upper_bound or '∞'}]"
+            bounds_label = QLabel(bounds_text)
+            bounds_label.setStyleSheet("color: gray; font-size: 9pt;")
+            layout.addWidget(bounds_label)
+
+        self._spinbox.valueChanged.connect(self._spinbox_value_changed)
+        parameter.value_changed.connect(self._parameter_value_changed)
+
+    @Slot(int)
+    def _spinbox_value_changed(self, new_value: int) -> None:
+        self.parameter.value = new_value
+
+    @Slot(int, bool)
+    def _parameter_value_changed(self, new_value: int, valid: bool) -> None:
+        self._spinbox.setValue(new_value)
+
+
+class FloatParameterWidget(ParameterWidget):
+    """
+    A widget to edit a floating point parameter with optional bounds.
+    """
+
+    def __init__(self, parameter: FloatParameter) -> None:
+        """
+        Initialize a FloatParameterWidget object.
+
+        :param parameter: the float parameter to reference
+        :type parameter: FloatParameter
+        """
+        super().__init__(parameter)
+
+        layout = QVBoxLayout(self)
+        self._spinbox = QDoubleSpinBox()
+        
+        # Set bounds if specified
+        if parameter.lower_bound is not None:
+            self._spinbox.setMinimum(parameter.lower_bound)
+        else:
+            self._spinbox.setMinimum(float('-inf'))
+            
+        if parameter.upper_bound is not None:
+            self._spinbox.setMaximum(parameter.upper_bound)
+        else:
+            self._spinbox.setMaximum(float('inf'))
+            
+        self._spinbox.setValue(parameter.value)
+        self._spinbox.setDecimals(4)  # Default precision
+        layout.addWidget(self._spinbox)
+
+        # Add bounds label if bounds are specified
+        if parameter.lower_bound is not None or parameter.upper_bound is not None:
+            bounds_text = f"Valid range: [{parameter.lower_bound or '-∞'}, {parameter.upper_bound or '∞'}]"
+            bounds_label = QLabel(bounds_text)
+            bounds_label.setStyleSheet("color: gray; font-size: 9pt;")
+            layout.addWidget(bounds_label)
+
+        self._spinbox.valueChanged.connect(self._spinbox_value_changed)
+        parameter.value_changed.connect(self._parameter_value_changed)
+
+    @Slot(float)
+    def _spinbox_value_changed(self, new_value: float) -> None:
+        self.parameter.value = new_value
+
+    @Slot(float, bool)
+    def _parameter_value_changed(self, new_value: float, valid: bool) -> None:
+        self._spinbox.setValue(new_value)


### PR DESCRIPTION
Fixes #3 #4

## Summary
Implements integer and floating point parameter support with optional bounds validation for the RAiSD-AI GUI.

## Changes

### Parameter Classes (`gui/model/parameter.py`)
- **IntParameter**: Integer parameter with optional `lower_bound` and `upper_bound`
- **FloatParameter**: Float parameter with optional `lower_bound` and `upper_bound`
- Both validate current value against bounds in the `valid` property
- CLI output format: `{flag} {value}`

### Widget Classes (`gui/widgets/parameter_widget.py`)
- **IntParameterWidget**: Uses `QSpinBox` for integer input
- **FloatParameterWidget**: Uses `QDoubleSpinBox` for float input (4 decimal precision)
- Both display bounds information label when bounds are specified
- Automatic validation via Qt's built-in range enforcement
- Two-way binding with signal/slot mechanism

### Factory Method
Updated `ParameterWidget.from_parameter()` to recognize and create appropriate widgets for `IntParameter` and `FloatParameter`.

## Example
```python
# Integer parameter with bounds [1, 100]
int_param = IntParameter("iterations", "Number of iterations", "-n",
                         default_value=10, lower_bound=1, upper_bound=100)

# Float parameter with bounds [0.0, 1.0]
float_param = FloatParameter("threshold", "Threshold value", "-t",
                             default_value=0.5, lower_bound=0.0, upper_bound=1.0)
```

## UI Features
- Spinboxes with increment/decrement buttons
- Bounds enforced automatically (prevents invalid input)
- Gray info label showing valid range (e.g., "Valid range: [1, 100]")
- Signal/slot updates keep parameter and widget in sync

## Testing
Tested with both bounded and unbounded parameters to ensure:
- Value changes trigger parameter updates
- Parameter changes update widget display
- Bounds are properly enforced by Qt validators
- CLI output format is correct