### PR TITLE
Add missing input formats to IMG-GEN in config file

### DIFF
--- a/gui/config.yaml
+++ b/gui/config.yaml
@@ -38,6 +38,9 @@ modes:
               type: single
               formats:
                 - .ms
+                - .mbs
+                - .vcf
+                - .fasta
         output:
           type: directory
           contents:


### PR DESCRIPTION
This PR adds the expected input types to IMG-GEN in the config file, which we missed in #73. This removes the long chains of file conversion in the operation trees.