### PR TITLE
Rename parameter

### DIFF
--- a/gui/config.yaml
+++ b/gui/config.yaml
@@ -786,7 +786,7 @@ parameter_groups:
       - VCF-MS
     parameters:
       "-L-vcf-ms":
-        name: Region length
+        name: Ms region length
         description: The region size (in basepairs) for the ms file obtained from the conversion. # ?
         cli: "-L "
         type: int


### PR DESCRIPTION
Fixes bug caused by multiple parameters having the same name.