### PR TITLE
Rename Standard Raisd as Raisd with μ statistic

### DIFF
--- a/gui/config.yaml
+++ b/gui/config.yaml
@@ -14,11 +14,11 @@ common_directory_overwrite_parameter:
   type: bool
   default: false
 modes:
-  - name: Standard RAiSD
+  - name: RAiSD with μ statistic
     operations:
       RSD-DEF:
-        name: Standard sweep scan
-        description: Do a sweep scan with standard RAiSD.
+        name: Sweep scan with μ statistic
+        description: Do a sweep scan with μ statistic.
         cli: ""
         input:
           - name: Input data


### PR DESCRIPTION
Renamed Standard RAiSD as RAiSD with μ statistic in the config file since Nikos asked for this change during our meeting.

I didn't see this was given as a task already, if it is done by another branch feel free to delete this pr