### PR TITLE
Give operations separate output and overwrite paths

### DIFF
--- a/gui/config.yaml
+++ b/gui/config.yaml
@@ -32,18 +32,23 @@ modes:
                 - .vcf
                 - .fasta
         output:
-          type: file
-          formats: 
-            - .txt
-        overwrite_parameter:
-          name: Overwrite RAiSD report
-          description: You might overwrite an existing RAiSD report. Are you sure?
-          cli: "-f"
-          type: bool
-          default: false
-        path:
-          - RAiSD_Info.
-          - type: run id
+          path:
+            - RAiSD_Report.
+            - type: run id
+          file:
+            type: single
+            formats: 
+              - .txt
+        overwrite:
+          path:
+            - RAiSD_Info.
+            - type: run id
+          parameter:
+            name: Overwrite RAiSD report
+            description: You might overwrite an existing RAiSD report. Are you sure?
+            cli: "-f"
+            type: bool
+            default: false
   - name: RAiSD-AI
     operations:
       IMG-GEN:
@@ -62,17 +67,31 @@ modes:
                 - .vcf
                 - .fasta
         output:
-          type: directory
-          contents:
-            - type: single
-              formats:
-                - .png
-        overwrite_parameter:
-          name: Overwrite prepared data
-          description: You might overwrite existing data in the output folder. Are you sure?
-          cli: "-f"
-          type: bool
-          default: false
+          path:
+            - RAiSD_Images.
+            - type: run id
+            - type: slash
+            - type: parameter
+              id: -icl
+          file:
+            type: directory
+            contents:
+              - type: single
+                formats:
+                  - .png
+        overwrite:
+          path:
+          - RAiSD_Info.
+          - type: run id
+          - .
+          - type: parameter
+            id: -icl
+          parameter:
+            name: Overwrite prepared data
+            description: You might overwrite existing data in the output folder. Are you sure?
+            cli: "-f"
+            type: bool
+            default: false
         parameters:
           "-icl":
             name: Image class label
@@ -94,12 +113,6 @@ modes:
               - type: interval
                 min: 1
               # max: < region_length
-        path:
-          - RAiSD_Info.
-          - type: run id
-          - .
-          - type: parameter
-            id: -icl
       MDL-GEN:
         name: Model training
         description: Train a sweep detection CNN model.
@@ -122,20 +135,25 @@ modes:
                       formats:
                         - .png
         output:
-          type: directory
-          contents:
-            - type: single
-              formats:
-                - .pt
-        overwrite_parameter:
-          name: Overwrite model
-          description: You might overwrite existing data in the output folder. Are you sure?
-          cli: "-f"
-          type: bool
-          default: false
-        path:
-          - RAiSD_Info.
-          - type: run id
+          path:
+            - RAiSD_Model.
+            - type: run id
+          file:
+            type: directory
+            contents:
+              - type: single
+                formats:
+                  - .pt
+        overwrite:
+          path:
+            - RAiSD_Info.
+            - type: run id
+          parameter:
+            name: Overwrite model
+            description: You might overwrite existing data in the output folder. Are you sure?
+            cli: "-f"
+            type: bool
+            default: false
       MDL-TST:
         name: Model testing
         description: Evaluate a sweep detection CNN model on a test dataset.
@@ -166,19 +184,24 @@ modes:
                     - type: single
                       formats:
                         - .png
-        output: 
-          type: single
-          formats:
-            - .txt
-        overwrite_parameter:
-          name: Overwrite results
-          description: You might overwrite existing data in the output folder. Are you sure?
-          cli: "-f"
-          type: bool
-          default: false
-        path:
-          - RAiSD_Info.
-          - type: run id
+        output:
+          path:
+            - RAiSD_Info.
+            - type: run id
+          file:
+            type: single
+            formats:
+              - .txt
+        overwrite:
+          path:
+            - RAiSD_Info.
+            - type: run id
+          parameter:
+            name: Overwrite results
+            description: You might overwrite existing data in the output folder. Are you sure?
+            cli: "-f"
+            type: bool
+            default: false
       SWP-SCN:
         name: Model sweep scan
         description: Use a CNN model to scan for selective sweeps.
@@ -204,18 +227,23 @@ modes:
                 - .vcf
                 - .fasta
         output:
-          type: single
-          formats:
-            - .txt
-        overwrite_parameter:
-          name: Overwrite report
-          description: You might overwrite an existing RAiSD report. Are you sure?
-          cli: "-f -frm"
-          type: bool
-          default: false
-        path:
-          - RAiSD_Info.
-          - type: run id
+          path:
+            - RAiSD_Info.
+            - type: run id
+          file:
+            type: single
+            formats:
+              - .txt
+        overwrite:
+          path:
+            - RAiSD_Info.
+            - type: run id
+          parameter:
+            name: Overwrite report
+            description: You might overwrite an existing RAiSD report. Are you sure?
+            cli: "-f -frm"
+            type: bool
+            default: false
   - name: Common outlier analysis
     operations:
       CO:
@@ -224,18 +252,23 @@ modes:
         cli: ""
         input: []
         output:
-          type: single
-          formats:
-            - .co-report
-        overwrite_parameter:
-          name: Overwrite existing results?
-          description: You might overwrite existing output data. Are you sure?
-          cli: "-f"
-          type: bool
-          default: false
-        path:
-          - RAiSD_Info.
-          - type: run id
+          path:
+            - RAiSD_Info.
+            - type: run id
+          file:
+            type: single
+            formats:
+              - .co-report
+        overwrite:
+          path:
+            - RAiSD_Info.
+            - type: run id
+          parameter:
+            name: Overwrite existing results?
+            description: You might overwrite existing output data. Are you sure?
+            cli: "-f"
+            type: bool
+            default: false
   - name: File conversion
     operations:
       FASTA-VCF:
@@ -251,18 +284,23 @@ modes:
               formats:
                 - .fasta
         output:
-          type: single
-          formats:
-            - .vcf
-        overwrite_parameter:
-          name: Overwrite existing data?
-          description: You might overwrite existing output data. Are you sure?
-          cli: "-f"
-          type: bool
-          default: false
-        path:
-          - RAiSD_Info.
-          - type: run id
+          path:
+            - RAiSD_Info.
+            - type: run id
+          file:
+            type: single
+            formats:
+              - .vcf
+        overwrite:
+          path:
+            - RAiSD_Info.
+            - type: run id
+          parameter:
+            name: Overwrite existing data?
+            description: You might overwrite existing output data. Are you sure?
+            cli: "-f"
+            type: bool
+            default: false
       VCF-MS:
         name: VCF to ms
         description: Convert a VCF file to ms.
@@ -276,18 +314,23 @@ modes:
               formats:
                 - .vcf
         output:
-          type: single
-          formats:
-            - .ms
-        overwrite_parameter:
-          name: Overwrite existing data?
-          description: You might overwrite existing output data. Are you sure?
-          cli: "-f"
-          type: bool
-          default: false
-        path:
-          - RAiSD_Info.
-          - type: run id
+          path:
+            - RAiSD_Info.
+            - type: run id
+          file:
+            type: single
+            formats:
+              - .ms
+        overwrite:
+          path:
+            - RAiSD_Info.
+            - type: run id
+          parameter:
+            name: Overwrite existing data?
+            description: You might overwrite existing output data. Are you sure?
+            cli: "-f"
+            type: bool
+            default: false
 parameter_groups:
   - name: SNP and sample handling
     operations:

--- a/gui/config.yaml
+++ b/gui/config.yaml
@@ -228,7 +228,7 @@ modes:
                 - .fasta
         output:
           path:
-            - RAiSD_Info.
+            - RAiSD_Report.
             - type: run id
           file:
             type: single

--- a/gui/model/operation/operation.py
+++ b/gui/model/operation/operation.py
@@ -50,4 +50,5 @@ class Operation():
     produces: FileStructure
     output_path: Sequence[PathFragment]
     overwrite_parameter_builder: Callable[[], Parameter[Any]]
+    overwrite_path: Sequence[PathFragment]
     parameter_builders: Mapping[str, Callable[[], Parameter[Any]]]

--- a/gui/model/operation/operation_tree.py
+++ b/gui/model/operation/operation_tree.py
@@ -83,6 +83,7 @@ class FileProducerNode(QObject):
             self.value = new_overwrite==self._target_value
 
     file_changed = Signal(str)
+    watched_files_changed = Signal(list[str])
     overwrite_changed = Signal(bool)
     valid_changed = Signal(bool)
 
@@ -90,6 +91,7 @@ class FileProducerNode(QObject):
         super().__init__()
         self._watcher = QFileSystemWatcher()
         self.file_changed.connect(self._update_watcher_path)
+        self.watched_files_changed.connect(self._update_watcher_path)
         self._watcher.fileChanged.connect(self._watched_file_changed)
         self._watcher.directoryChanged.connect(self._watched_file_changed)
 
@@ -106,6 +108,13 @@ class FileProducerNode(QObject):
         The path to the file produced by this node, if available.
         """
         raise NotImplementedError()
+
+    @property
+    def watched_files(self) -> list[str]:
+        """
+        The paths to the file this node needs to watch for changes.
+        """
+        return []
 
     @property
     def overwrite(self) -> bool:
@@ -178,17 +187,17 @@ class FileProducerNode(QObject):
 
     @Slot()
     def _update_watcher_path(self) -> None:
-        # Remove the watched path, if any.
+        # Remove the watched paths, if any.
         paths = self._watcher.files() + self._watcher.directories()
         if paths:
             self._watcher.removePaths(paths)
 
-        # Watch the closest existing ancestor of the output location.
-        file = self.file
-        added: bool = False
-        while file and not added:
-            added = self._watcher.addPath(file)
-            file = QFileInfo(file).dir().absolutePath()
+        # Watch the closest existing ancestor of each watched file.
+        for file in self.watched_files:
+            added: bool = False
+            while file and not added:
+                added = self._watcher.addPath(file)
+                file = QFileInfo(file).dir().absolutePath()
 
     @Slot()
     def _watched_file_changed(self) -> None:
@@ -528,6 +537,13 @@ class CommonParentDirectoryNode(FileProducerNode):
         if len(parent_directory_paths) == 1:
             return list(parent_directory_paths)[0]
         return None
+
+    @property
+    def watched_files(self) -> list[str]:
+        file = self.file
+        if file:
+            return [file]
+        return []
 
     @property
     def overwrite(self) -> bool:
@@ -1046,6 +1062,15 @@ class OperationNode(FileProducerNode):
             )
             for path_fragment in operation.output_path
         ]
+
+        self._overwrite_path = [
+            OperationNode.PathFragmentGenerator.from_path_fragment(
+                path_fragment=path_fragment,
+                operation_node=self,
+            )
+            for path_fragment in operation.overwrite_path
+        ]
+
         self._run_id = run_id
         self._base_directory_path = base_directory_path
         self._enabled = enabled
@@ -1179,8 +1204,21 @@ class OperationNode(FileProducerNode):
         )
 
     @property
+    def overwrite_file(self) -> str:
+        """
+        The path to the file to check for an overwrite.
+        """
+        return QDir(self.base_directory_path).absoluteFilePath(
+            "".join(generator.value for generator in self._overwrite_path)
+        )
+
+    @property
+    def watched_files(self) -> list[str]:
+        return [self.overwrite_file]
+
+    @property
     def overwrite(self) -> bool:
-        return QFileInfo(self.file).exists()
+        return QFileInfo(self.overwrite_file).exists()
 
     @property
     def valid(self) -> bool:

--- a/gui/model/run_record.py
+++ b/gui/model/run_record.py
@@ -267,35 +267,79 @@ class RunRecord(QObject):
                 
                 requires.append(parse_operation_input(requires_obj))
 
-            produces_obj = obj.get("output", "") or ""
-            if not isinstance(produces_obj, dict):
+            # Output path and file structure
+            if "output" not in obj:
                 raise ValueError(
-                    f"Invalid output for operation: {produces_obj}."
-                    + "Expected object."
+                    f"Missing output object for operation {name}."
                 )
-            produces = parse_file_structure(produces_obj)
+            output_obj = obj["output"]
+            if not isinstance(output_obj, dict):
+                raise ValueError(
+                    f"Invalid output object for operation {name}: {output_obj}"
+                    + ". Expected an object."
+                )
 
-            if "path" not in obj:
+            if "path" not in output_obj:
                 raise ValueError(
                     f"No output path provided for operation {name}."
                 )
-            path_fragments_list = obj["path"]
-            if not isinstance(path_fragments_list, list):
+            output_path_fragments_list = output_obj["path"]
+            if not isinstance(output_path_fragments_list, list):
                 raise ValueError(
                     f"Invalid output path for operation {name}: "
-                    + f"{path_fragments_list}. Expected a list."
+                    + f"{output_path_fragments_list}. Expected a list."
                 )
-            path_fragments: list[Operation.PathFragment] = []
-            for path_fragment_obj in path_fragments_list:
-                path_fragments.append(
+            output_path_fragments: list[Operation.PathFragment] = []
+            for path_fragment_obj in output_path_fragments_list:
+                output_path_fragments.append(
                     parse_path_fragment(path_fragment_obj),
                 )
 
-            if "overwrite_parameter" not in obj:
+            if "file" not in output_obj:
+                raise ValueError(
+                    f"Missing output file structure for operation {name}."
+                )
+            produces_obj = output_obj["file"]
+            if not isinstance(produces_obj, dict):
+                raise ValueError(
+                    f"Invalid output file structure for operation {name}: "
+                    + f"{produces_obj}. Expected an object."
+                )
+            produces = parse_file_structure(produces_obj)
+
+            # Overwrite path and parameter
+            if "overwrite" not in obj:
+                raise ValueError(
+                    f"Missing overwrite object for operation {name}."
+                )
+            overwrite_obj = obj["overwrite"]
+            if not isinstance(overwrite_obj, dict):
+                raise ValueError(
+                    f"Invalid overwrite object for operation {name}: "
+                    + f"{overwrite_obj}. Expected an object."
+                )
+
+            if "path" not in overwrite_obj:
+                raise ValueError(
+                    f"No overwrite path provided for operation {name}."
+                )
+            overwrite_path_fragments_list = overwrite_obj["path"]
+            if not isinstance(overwrite_path_fragments_list, list):
+                raise ValueError(
+                    f"Invalid output path for operation {name}: "
+                    + f"{overwrite_path_fragments_list}. Expected a list."
+                )
+            overwrite_path_fragments: list[Operation.PathFragment] = []
+            for path_fragment_obj in overwrite_path_fragments_list:
+                overwrite_path_fragments.append(
+                    parse_path_fragment(path_fragment_obj),
+                )
+
+            if "parameter" not in overwrite_obj:
                 raise ValueError(
                     f"Missing overwrite parameter for operation {name}."
                 )
-            overwrite_parameter_obj = obj["overwrite_parameter"]
+            overwrite_parameter_obj = overwrite_obj["parameter"]
             overwrite_parameter_builder = (
                 lambda: parse_parameter(
                     obj=overwrite_parameter_obj,
@@ -326,7 +370,8 @@ class RunRecord(QObject):
                 cli=cli,
                 requires=requires,
                 produces=produces,
-                output_path=path_fragments,
+                output_path=output_path_fragments,
+                overwrite_path=overwrite_path_fragments,
                 overwrite_parameter_builder=overwrite_parameter_builder,
                 parameter_builders=parameter_builders,
             )


### PR DESCRIPTION
Through a major oversight in #174, I broke the functionality of running multiple operations together, since the operations no longer give the correct output locations to pass on as input. This PR intends to address that by giving each operation a separate operation path and output path which can be used independently.