### PR TITLE
Fix state of "next" button on operation selection tab

### DIFF
--- a/gui/model/operation/operation_tree.py
+++ b/gui/model/operation/operation_tree.py
@@ -553,6 +553,7 @@ class CommonParentDirectoryNode(FileProducerNode):
     def _set_run_id(self, new_run_id: str) -> None:
         old_file = self.file
         old_overwrite = self.overwrite
+        old_valid = self.valid
 
         for file_consumer in self.file_consumers:
             file_consumer.run_id = new_run_id
@@ -561,12 +562,15 @@ class CommonParentDirectoryNode(FileProducerNode):
             self.file_changed.emit(self.file)
         if self.overwrite != old_overwrite:
             self.overwrite_changed.emit(self.overwrite)
+        if self.valid != old_valid:
+            self.valid_changed.emit(self.valid)
 
     run_id = property(fset=_set_run_id)
 
     def _set_base_directory_path(self, new_base_directory_path: str) -> None:
         old_file = self.file
         old_overwrite = self.overwrite
+        old_valid = self.valid
 
         for file_consumer in self.file_consumers:
             file_consumer.base_directory_path = new_base_directory_path
@@ -575,6 +579,8 @@ class CommonParentDirectoryNode(FileProducerNode):
             self.file_changed.emit(self.file)
         if self.overwrite != old_overwrite:
             self.overwrite_changed.emit(self.overwrite)
+        if self.valid != old_valid:
+            self.valid_changed.emit(self.valid)
 
     base_directory_path = property(fset=_set_base_directory_path)
 
@@ -1148,6 +1154,7 @@ class OperationNode(FileProducerNode):
     def run_id(self, new_run_id: str) -> None:
         old_file = self.file
         old_overwrite = self.overwrite
+        old_valid = self.valid
         old_run_id = self.run_id
 
         self._run_id = f"{new_run_id}_{self.id}"
@@ -1158,6 +1165,8 @@ class OperationNode(FileProducerNode):
             self.file_changed.emit(self.file)
         if self.overwrite != old_overwrite:
             self.overwrite_changed.emit(self.overwrite)
+        if self.valid != old_valid:
+            self.valid_changed.emit(self.valid)
         if self.run_id != old_run_id:
             self.run_id_changed.emit(self.run_id)
 
@@ -1169,6 +1178,7 @@ class OperationNode(FileProducerNode):
     def base_directory_path(self, new_base_directory_path: str) -> None:
         old_file = self.file
         old_overwrite = self.overwrite
+        old_valid = self.valid
 
         self._base_directory_path = new_base_directory_path
         for file_consumer in self.file_consumers:
@@ -1178,6 +1188,8 @@ class OperationNode(FileProducerNode):
             self.file_changed.emit(self.file)
         if self.overwrite != old_overwrite:
             self.overwrite_changed.emit(self.overwrite)
+        if self.valid != old_valid:
+            self.valid_changed.emit(self.valid)
 
     @property
     def enabled(self) -> bool:

--- a/gui/model/run_record.py
+++ b/gui/model/run_record.py
@@ -1423,7 +1423,6 @@ class RunRecord(QObject):
         new_run_id: str,
         new_valid: bool,
     ) -> None:
-        self.run_id = new_run_id
         self.run_id_valid_changed.emit(self.run_id_valid)
         for operation_tree in self.operation_trees:
             operation_tree.run_id = new_run_id


### PR DESCRIPTION
This PR fixes a bug that used to be produced with the following steps:
1. Run a successful run (I did Model Testing, with all sub-operations selected).
2. Click edit run. The overwrite warnings are displayed and the next button is disabled.
3. Add one character to the run ID. BUG: despite the new run ID not existing, the next button is still disabled. The overwrite warnings have gone away.
4. Remove the extra character in the run ID. BUG: the next button is now enabled, even though the new run ID has been used before and the overwrite warnings are shown.

Please check that this works now, and the bug is gone!